### PR TITLE
Fix locale naming on macOS

### DIFF
--- a/CmakeGMKP/CMakeLists.txt
+++ b/CmakeGMKP/CMakeLists.txt
@@ -48,6 +48,10 @@ endif ()
 file(GLOB HEADER_FILES include/*.h)
 file(GLOB SOURCE_FILES src/*.cpp)
 
+if(APPLE)
+    message("Adding -DAPPLE")
+    add_definitions(-DAPPLE)
+endif()
 ######## Set executable file name, and add the source files for it.
 add_executable(GMKP ${HEADER_FILES} ${SOURCE_FILES})
 ######## Add Dependency Library

--- a/GMKP/OPL_CONV.cpp
+++ b/GMKP/OPL_CONV.cpp
@@ -5,7 +5,11 @@ int convertToOPL(int n, int m, int r, int * b, int * weights, int * profits, int
 	std::ofstream outfile(modFilename);
 
 	auto time = std::time(nullptr);
+#ifdef APPLE
+	std::cout.imbue(std::locale("en_US.UTF-8"));
+#elif
 	std::cout.imbue(std::locale("en_US.utf8"));
+#endif
 
 	outfile << "/*********************************************" << std::endl;
 	outfile << " * OPL 12.9.0.0 Model" << std::endl;


### PR DESCRIPTION
Locales have a slightly different naming scheme on macOS, which prevents successful printing of results. This  PR adds a compilation flag and an ifdef-guarded string compilation.

I also modified CMakeLists.txt to find CPLEX 12.10.